### PR TITLE
Reworked usage of PPL inside BluetoothSerial

### DIFF
--- a/source/Serial/BluetoothSerial.h
+++ b/source/Serial/BluetoothSerial.h
@@ -111,7 +111,7 @@ private:
 		bool synchronous_mode_
 	);
 
-	Concurrency::task<bool>
+	Concurrency::task<void>
 	connectAsync(
 		Windows::Devices::Enumeration::DeviceInformation ^device_
 	);


### PR DESCRIPTION
I've reworked the usage of PPL, avoiding the need for creating an independent std::thread and also the need for std::this_thread::sleep_for.

Instead of swallowing exceptions inside connectAsync, I let them bubble out. In the future, it would be good to let the users actually get these errors -- how else are they supposed to know why "ConnectionFailed" was called?