### PR TITLE
Switched out volatile & std::async for std::atomic & std::thread

### DIFF
--- a/source/Firmata/UwpFirmata.h
+++ b/source/Firmata/UwpFirmata.h
@@ -378,9 +378,9 @@ public:
 	  //common buffer
 	  uint8_t *_dataBuffer;
 
-	  //threading state member variables
-	  volatile bool inputThreadRunning;
-	  volatile bool inputThreadExited;
+	  //member variables to hold the current input thread & communications
+	  std::thread _inputThread;
+	  std::atomic<bool> _inputThreadShouldExit;
 
 	  //input-thread related functions
 	  void inputThread(void);

--- a/source/Firmata/UwpFirmata.h
+++ b/source/Firmata/UwpFirmata.h
@@ -25,6 +25,8 @@
 #pragma once
 
 #include <cstdint>
+#include <thread>
+#include <atomic>
 
 using namespace Platform;
 using namespace Concurrency;


### PR DESCRIPTION
Volatile is not appropriate for inter-thread communication and has incorrect behavior.
(http://stackoverflow.com/questions/12878344/volatile-in-c11)

Additionally, std::thread is preferred over std::async for applications which track their threads (read: all applications).
