### PR TITLE
[bug fix] Added connectionReady verification to flush() calls

### DIFF
--- a/source/Serial/BluetoothSerial.cpp
+++ b/source/Serial/BluetoothSerial.cpp
@@ -194,6 +194,11 @@ BluetoothSerial::flush(
     void
     )
 {
+    if( !connectionReady() )
+    {
+        return;
+    }
+
     auto async_operation_ = _tx->StoreAsync();
     create_task( _tx->StoreAsync() )
         .then( [ this, async_operation_ ]( unsigned int value_ )

--- a/source/Serial/DfRobotBleSerial.cpp
+++ b/source/Serial/DfRobotBleSerial.cpp
@@ -192,6 +192,11 @@ DfRobotBleSerial::flush(
     void
     )
 {
+    if( !connectionReady() )
+    {
+        return;
+    }
+
     create_task(_gatt_characteristic->WriteValueAsync(_tx->DetachBuffer(), GattWriteOption::WriteWithResponse))
         .then([this](GattCommunicationStatus status_)
     {

--- a/source/Serial/NetworkSerial.cpp
+++ b/source/Serial/NetworkSerial.cpp
@@ -150,6 +150,11 @@ NetworkSerial::flush(
     void
     )
 {
+    if( !connectionReady() )
+    {
+        return;
+    }
+
     auto async_operation_ = _tx->StoreAsync();
     create_task( async_operation_ )
         .then( [ this, async_operation_ ]( unsigned int value_ )

--- a/source/Serial/USBSerial.cpp
+++ b/source/Serial/USBSerial.cpp
@@ -208,6 +208,11 @@ UsbSerial::flush(
     void
     )
 {
+    if( !connectionReady() )
+    {
+        return;
+    }
+
     auto async_operation_ = _tx->StoreAsync();
     create_task( async_operation_ )
         .then( [ this, async_operation_ ]( task<unsigned int> task_ )


### PR DESCRIPTION
Fixing a potential issue when flush is called before connection established or after the connection is terminated.