### PR TITLE
"Unlocked" the SERVO pinMode

### DIFF
--- a/source/RemoteWiring/RemoteDevice.cpp
+++ b/source/RemoteWiring/RemoteDevice.cpp
@@ -139,7 +139,7 @@ RemoteDevice::analogWrite(
             pinMode( pin_, PinMode::PWM );
             _pin_mode[ pin_ ] = static_cast<uint8_t>( PinMode::PWM );
         }
-        else {
+        else if (_pin_mode[pin_] != static_cast<uint8_t>(PinMode::SERVO)) {
             return;
         }
     }


### PR DESCRIPTION
The SERVO mode was ready to use on the StandardFirmata. By stopping to ignore the Servo PinMode I successfully attached servos and sent commands to them without any issues