### PR TITLE
Fix the Bug that digitalRead() doesn't work properly.

### DIFF
--- a/source/Serial/USBSerial.cpp
+++ b/source/Serial/USBSerial.cpp
@@ -31,6 +31,7 @@ using namespace Concurrency;
 using namespace Windows::Devices::Enumeration;
 using namespace Windows::Devices::SerialCommunication;
 using namespace Windows::Storage::Streams;
+using namespace Windows::Foundation;
 
 using namespace Microsoft::Maker::Serial;
 
@@ -330,6 +331,10 @@ UsbSerial::connectToDeviceAsync(
         _serial_device->Handshake = SerialHandshake::None;
         _serial_device->BaudRate = _baud;
         _serial_device->IsDataTerminalReadyEnabled = true;
+
+        // 1ms read time out to avoid stucking in the LoadAsync() function.
+        serialReadTimeOut.Duration = 10000; 
+        _serial_device->ReadTimeout = serialReadTimeOut;
 
         switch (_config) {
         case SerialConfig::SERIAL_5E1:

--- a/source/Serial/USBSerial.h
+++ b/source/Serial/USBSerial.h
@@ -27,6 +27,8 @@
 #include "IStream.h"
 #include <mutex>
 
+using namespace Windows::Foundation;
+
 namespace Microsoft {
 namespace Maker {
 namespace Serial {

--- a/source/Serial/USBSerial.h
+++ b/source/Serial/USBSerial.h
@@ -152,6 +152,8 @@ private:
     Windows::Storage::Streams::DataReader ^_rx;
     Windows::Storage::Streams::DataWriter ^_tx;
 
+    TimeSpan serialReadTimeOut;
+
     Concurrency::task<void>
     connectToDeviceAsync(
         Windows::Devices::Enumeration::DeviceInformation ^device_


### PR DESCRIPTION
Reason: LoadAsync() is stuck when reading the Serial data.
Change the read timeout duration will fix it.