### PR TITLE
Fix integer underflow in UwpFirmata::reassembleByteString

### DIFF
--- a/source/Firmata/UwpFirmata.cpp
+++ b/source/Firmata/UwpFirmata.cpp
@@ -594,11 +594,11 @@ UwpFirmata::reassembleByteString(
     )
 {
     //each char must be reassembled from the two 7-bit bytes received, therefore length should always be an even number.
-	size_t i;
-	for( i = 0; i < length_ / 2; ++i )
-	{
-		byte_string_[i] = byte_string_[i * 2 + 0] | ( byte_string_[i * 2 + 1] << 7 );
-	}
+    size_t i;
+    for( i = 0; i < length_ / 2; ++i )
+    {
+        byte_string_[i] = byte_string_[i * 2 + 0] | ( byte_string_[i * 2 + 1] << 7 );
+    }
     byte_string_[i] = 0;
 }
 

--- a/source/Firmata/UwpFirmata.cpp
+++ b/source/Firmata/UwpFirmata.cpp
@@ -594,11 +594,11 @@ UwpFirmata::reassembleByteString(
     )
 {
     //each char must be reassembled from the two 7-bit bytes received, therefore length should always be an even number.
-    size_t i, j;
-    for( i = 0, j = 0; j < length_ - 1; ++i, j += 2 )
-    {
-        byte_string_[i] = byte_string_[j] | ( byte_string_[j + 1] << 7 );
-    }
+	size_t i;
+	for( i = 0; i < length_ / 2; ++i )
+	{
+		byte_string_[i] = byte_string_[i * 2 + 0] | ( byte_string_[i * 2 + 1] << 7 );
+	}
     byte_string_[i] = 0;
 }
 


### PR DESCRIPTION
The current implementation of UwpFirmata::reassembleByteString does not properly handle strings of length 0. When given an empty string, the comparison on line 598 underflows length_ to SIZE_MAX. This causes the loop the never terminate and read/write past the end of the input buffer.

This can be triggered if the remote device sends the following bytes to the library "0xF0, 0x71, 0xF7".
