### PR TITLE
Adding flush to complete commands

### DIFF
--- a/source/Firmata/UwpFirmata.cpp
+++ b/source/Firmata/UwpFirmata.cpp
@@ -423,6 +423,7 @@ UwpFirmata::sendString(
         }
 
         _firmata_stream->write( static_cast<uint8_t>( Command::END_SYSEX ) );
+        _firmata_stream->flush();
     }
 }
 
@@ -454,6 +455,7 @@ UwpFirmata::sendSysex(
     }
 
     _firmata_stream->write( static_cast<uint8_t>( Command::END_SYSEX ) );
+    _firmata_stream->flush();
 }
 
 void


### PR DESCRIPTION
sendString and sendSysex are complete requests that should be executed fully when the functions are invoked. For that to work properly, the underlying stream should be flushed to complete the request.