### PR TITLE
Add optional polling interval to reduce CPU usage

### DIFF
--- a/source/Firmata/UwpFirmata.cpp
+++ b/source/Firmata/UwpFirmata.cpp
@@ -48,11 +48,25 @@ UwpFirmata::UwpFirmata(
     _firmata_stream(nullptr),
     _connection_ready(ATOMIC_VAR_INIT(false)),
     _input_thread_should_exit(ATOMIC_VAR_INIT(false)),
+    _polling_interval(0),
     firmwareVersionMajor(0),
     firmwareVersionMinor(0)
 {
 }
 
+UwpFirmata::UwpFirmata(
+    uint64_t polling_interval_
+) :
+    _data_buffer(new uint16_t[DATA_BUFFER_SIZE]),
+    _firmata_lock(_firmutex, std::defer_lock),
+    _firmata_stream(nullptr),
+    _connection_ready(ATOMIC_VAR_INIT(false)),
+    _input_thread_should_exit(ATOMIC_VAR_INIT(false)),
+    _polling_interval(polling_interval_),
+    firmwareVersionMajor(0),
+    firmwareVersionMinor(0)
+{
+}
 
 //******************************************************************************
 //* Destructors
@@ -555,6 +569,11 @@ UwpFirmata::inputThread(
         catch( Platform::Exception ^e )
         {
             OutputDebugString( e->Message->Begin() );
+        }
+
+        if (_polling_interval)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(_polling_interval));
         }
     }
 }

--- a/source/Firmata/UwpFirmata.h
+++ b/source/Firmata/UwpFirmata.h
@@ -191,6 +191,10 @@ public:
         void
     );
 
+    UwpFirmata(
+        uint64_t polling_interval_
+    );
+
     virtual
     ~UwpFirmata(
         void
@@ -400,6 +404,7 @@ public:
     //input thread & behavior mechanisms
     std::thread _input_thread;
     std::atomic_bool _input_thread_should_exit;
+    uint64_t _polling_interval;
 
     String ^
     createStringFromMbs(


### PR DESCRIPTION
As soon as Firmata.begin is called one of the cores of my Raspberry Pi 3 is fully utilized.
While this might be necessary for highly latency dependent applications, it seems like total overkill for basic usage of the firmata protocol.

This Pull Request introduces a second UwpFirmata(ulong pollingInterval) constructor that sleeps the inputThread() for the given amount of micro seconds.

A value of for example 10ms reduces the CPU usage to non noticable levels and is still entirely sufficent for simple non realtime data polling vie SYSEX